### PR TITLE
Fix some renamed arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ by codept
      only analyze files which are an ancestor of the module `modulename`.Note that the input name is capitalized and extension are removed to avoid some discomfort.
 
 
-   * `-transparent-extension-node bool`
+   * `-extension-node bool`
    decide what to do with extension nodes, if `bool` is true, extension node are considered as transparent and analyzed, otherwise they are left alone. Note that ocaml built-in extension nodes (i.e. `[%extension_constructor … ]` nodes)  are always analyzed and are not affected by this option.
 
 

--- a/docs/codept.1
+++ b/docs/codept.1
@@ -164,7 +164,7 @@ Note that the input name is capitalized and extension are removed to avoid
 some discomfort.
 
 .TP
-.BI -transparent-extension-node \ bool
+.BI -extension-node \ bool
 decide what to do with extension nodes,
 if `bool` is true, extension node are considered as transparent and analyzed,
 otherwise they are left alone. Note that ocaml built-in extension nodes

--- a/ocamlbuild/codept_ocamlbuild.ml
+++ b/ocamlbuild/codept_ocamlbuild.ml
@@ -3,7 +3,7 @@ open Ocamlbuild_plugin
 let mdeps = A "-nl-modules"
 let fdeps = A "-modules"
 let gen_sig = A "-sig"
-let m2l_gen = A "-m2l-sexp"
+let m2l_gen = A "-m2l"
 let o = A "-o"
 
 let is_pflag_included root s =

--- a/ocamlbuild/myocamlbuild_cs.ml
+++ b/ocamlbuild/myocamlbuild_cs.ml
@@ -5,7 +5,7 @@ open Ocamlbuild_plugin
 let mdeps = A "-nl-modules"
 let fdeps = A "-modules"
 let gen_sig = A "-sig"
-let m2l_gen = A "-m2l-sexp"
+let m2l_gen = A "-m2l"
 let o = A "-o"
 
 let is_pflag_included root s =

--- a/ocamlbuild_plugin/codept_ocamlbuild.ml
+++ b/ocamlbuild_plugin/codept_ocamlbuild.ml
@@ -3,7 +3,7 @@ open Ocamlbuild_plugin
 let mdeps = A "-nl-modules"
 let fdeps = A "-modules"
 let gen_sig = A "-sig"
-let m2l_gen = A "-m2l-sexp"
+let m2l_gen = A "-m2l"
 let o = A "-o"
 
 let is_pflag_included root s =


### PR DESCRIPTION
While digging around I found some mentioned arguments which no longer match `args.ml`.