### PR TITLE
Fix the implementation of Support.{remove_,}extension and update tests

### DIFF
--- a/lib/support.ml
+++ b/lib/support.ml
@@ -1,18 +1,32 @@
-let extension_pos name =
-    let n = String.length name in
-  let r = try String.rindex name '.' with Not_found -> n-1 in
-    if r = 0 then
-      try String.rindex name '.' with Not_found -> n-1
-    else r
+(* Xavier Leroy & Damien Doligez, INRIA Rocquencourt (c) 1996 *)
+
+let is_dir_sep_win32 s i = let c = s.[i] in c = '/' || c = '\\' || c = ':'
+let is_dir_sep_unix s i = s.[i] = '/'
+let is_dir_sep = match Sys.os_type with
+  | "Win32" -> is_dir_sep_win32
+  | _ -> is_dir_sep_unix
+
+let extension_len name =
+  let rec check i0 i =
+    if i < 0 || is_dir_sep name i then 0
+    else if name.[i] = '.' then check i0 (i - 1)
+    else String.length name - i0 in
+  let rec search_dot i =
+    if i < 0 || is_dir_sep name i then 0
+    else if name.[i] = '.' then check i (i - 1)
+    else search_dot (i - 1) in
+  search_dot (String.length name - 1)
 
 let extension name =
-  let n = String.length name in
-  let r = extension_pos name in
-  String.sub name (r+1) (n-r-1)
+  let l = extension_len name in
+  if l = 0 then "" else
+  let l = l - 1 in
+  String.sub name (String.length name - l) l
 
 let remove_extension name =
-  let r = extension_pos name in
-  String.sub name 0 r
+  let l = extension_len name in
+  if l = 0 then name else
+  String.sub name 0 (String.length name - l)
 
 let split_on_char sep s =
   let sub start stop =

--- a/lib/support.mli
+++ b/lib/support.mli
@@ -1,7 +1,25 @@
 (** Support module for recently introduced function in stdlib *)
 
 val extension: string -> string
+(** [extension name] is the shortest suffix [ext] of [name0] where:
+    - [name0] is the longest suffix of [name] that does not contain
+      a directory separator;
+    - [ext] does {b not} starts with a period (such as
+      [name0 ^ "." ^ ext = name])
+    - [ext] plus the dot is preceded by at least one non-period character in
+      [name0].
+
+    If such a suffix does not exist, [extension name] is the empty string. *)
+
 val remove_extension: string -> string
+(** Return the given file name without its extension, as defined in
+    {!val:extension}. If the extension is empty, the function returns the given
+    file name.
+
+    The following invariant holds for any file name [s]:
+    [remove_extension s ^ "." ^ extension s = s]
+*)
+
 val split_on_char: char -> string -> string list
 val opt: ('a -> 'b) -> 'a -> 'b option
 val filter_map: ('a -> 'b option) -> 'a list -> 'b list

--- a/tests/run.ml
+++ b/tests/run.ml
@@ -695,7 +695,7 @@ let result =
              "Standard_faults"],
             [ "List"; "Location"; "Set"],
             []);
-          "support.ml", ([],["String"; "List"],[]);
+          "support.ml", ([],["String"; "List"; "Sys"],[]);
           "support.mli", ([],[],[]);
           "with_deps.ml", (["Deps"],[],[]);
           "with_deps.mli", (["Deps"],[],[]);


### PR DESCRIPTION
A simple fix for #16 where I decided to took the implementation from OCaml (and add the copyright). The `support` module depends on `Sys` now and the patch seems to modify the order of modules into the `module_collision` tests.