### PR TITLE
Use `cuts` instead of `split_on_char`

### DIFF
--- a/core/args.ml
+++ b/core/args.ml
@@ -137,10 +137,10 @@ let print_vnum version ()= Format.printf "%.2f@." version
 let print_version version ()= Format.printf "codept, version %.2f@." version
 
 let fault param s =
-  match Support.split_on_char '=' s with
+  match Support.cuts ~empty:false ~sep:"=" s with
   | [] | [_]| _ :: _ :: _ :: _ -> ()
   | [a;b] ->
-    let path= List.map String.trim @@ Support.split_on_char '.' a in
+    let path= List.map String.trim @@ Support.cuts ~empty:false ~sep:"." a in
     let level = Fault.Level.of_string b in
     fmap param L.policy (Fault.Policy.set ~lvl:level path)
 
@@ -186,7 +186,7 @@ let pkg param findlib_query =
       fmap param L.precomputed_libs (Name.Set.add s)
     else
       findlib_query := Findlib.pkg !findlib_query s in
-  Cmd.String( fun s -> List.iter add @@ Support.split_on_char ',' s )
+  Cmd.String( fun s -> List.iter add @@ Support.cuts ~empty:false ~sep:"," s )
 
 let no_stdlib param =
   Cmd.Unit( fun () -> fmap param L.precomputed_libs @@ Name.Set.remove "stdlib" )

--- a/core/findlib.ml
+++ b/core/findlib.ml
@@ -68,7 +68,7 @@ let process_pkg info name =
 let pkg info pkg = { info with pkgs = pkg :: info.pkgs }
 let syntax info syntax = { info with syntaxes = syntax :: info.syntaxes }
 let ppxopt info opt =
-  match Support.split_on_char ',' opt with
+  match Support.cuts ~empty:false ~sep:"," opt with
   | [] | [_] -> info
   | a :: q ->
     let q = String.concat "," q in
@@ -80,7 +80,7 @@ let ppxopt info opt =
 let ppopt info opt = { info with ppopt = opt :: info.ppopt }
 
 let predicates info s =
-  let l = List.map String.trim @@ Support.split_on_char ',' s in
+  let l = List.map String.trim @@ Support.cuts ~empty:false ~sep:"," s in
   { info with predicates = l @ info.predicates }
 
 let empty =

--- a/core/task.ml
+++ b/core/task.ml
@@ -35,10 +35,10 @@ type unit_desc =
   { filename: string; prefix:Paths.S.t; explicit_path: Namespaced.t option }
 
 let parse_name name =
-  match Support.split_on_char ':' name with
+  match Support.cuts ~empty:false ~sep:":" name with
   | [_] -> { filename=name; prefix=[]; explicit_path=None }
   | [a;b] ->
-    { filename = a; prefix = []; explicit_path= Some (Namespaced.of_path @@ Support.split_on_char '.' b)}
+    { filename = a; prefix = []; explicit_path= Some (Namespaced.of_path @@ Support.cuts ~empty:false ~sep:"." b)}
   | _ ->
     raise (Invalid_file_group "Multiple module path associated to the same file")
 
@@ -50,7 +50,7 @@ let (--*) start stop = start -- (stop-1)
 
 let decorate m udesc =
   let nms = List.filter ((<>) "") @@
-    List.map String.capitalize_ascii @@ Support.split_on_char '.' m in
+    List.map String.capitalize_ascii @@ Support.cuts ~empty:false ~sep:"." m in
   { udesc with prefix =  nms @ udesc.prefix }
 
 let rec parse_top s pos =

--- a/lib/paths.ml
+++ b/lib/paths.ml
@@ -66,9 +66,9 @@ struct
     | a :: q -> a :: chop_extension q
 
   let parse_filename name =
-    let l = Support.split_on_char (String.get (Filename.dir_sep) 0) name in
-    match List.rev l with
-    | "" :: q -> List.rev q
+    Support.cuts ~empty:true ~sep:Filename.dir_sep name
+    |> List.rev |> function
+    | "" :: l -> List.rev l
     | l -> List.rev l
 
   let module_name = module_name

--- a/lib/support.mli
+++ b/lib/support.mli
@@ -20,6 +20,21 @@ val remove_extension: string -> string
     [remove_extension s ^ "." ^ extension s = s]
 *)
 
-val split_on_char: char -> string -> string list
 val opt: ('a -> 'b) -> 'a -> 'b option
 val filter_map: ('a -> 'b option) -> 'a list -> 'b list
+
+val cuts : empty:bool -> sep:string -> string -> string list
+(** [cuts ~empty ~sep s] is the list of all substrings of [s] that are
+    delimited by matches of the non empty separator string [sep]. Empty
+    substrings are omitted in the list if [empty] is [false].
+
+    Matching separators in [s] starts from the beginning of [s]. Once one
+    is found, the separator is skipped and matching starts again, that is
+    separator matches can't overlap. If there is no separator match in [s],
+    the list [[s]] is returned.
+
+    The following invariants hold:
+    - [String.concat sep (cuts ~empty:true ~sep s) = s]
+    - [cuts ~empty:true ~sep s <> []]
+
+    @raise Invalid_argument if [sep] is the empty string. *)

--- a/tests/run.ml
+++ b/tests/run.ml
@@ -268,7 +268,7 @@ let std =
 
 let d x =
   x,
-  let nms = List.map String.capitalize_ascii @@ Support.split_on_char '/' x in
+  let nms = List.map String.capitalize_ascii @@ Support.cuts ~empty:false ~sep:"/" x in
   let n = Namespaced.of_path nms in
   let name = Paths.S.(module_name @@ parse_filename n.name) in
   { n with name }


### PR DESCRIPTION
This PR is a possible improvement about what we expect when we use the basic function `split_on_char`. From my point of view, `String.split_on_char` is problematic because:
- the function can split only on a character (it's better to write `cuts ~sep:Filename.dir_sep` instead of `split_on_char ~sep:Filename.dir_sep.[0]` - especially when this value depends on the system)
- the function by default keeps _empty_ parts. Sometimes, it's needed (especially for `Paths.S.parse_filename`) but sometimes it's not needed (others usages) and such behavior can lead to undefined behavior

For these two reasons, `Support.cuts` (took from the great [`astring`](https://github.com/dbuenzli/astring)):
- take a `string` as a separator
- explicit when we want to keep _empty_ parts or not (and be sure about what we manipulate by this way)

The documentation explicits invariants too.