### PR TITLE
Clarify some types into the module `fault.ml`

### DIFF
--- a/lib/fault.ml
+++ b/lib/fault.ml
@@ -1,4 +1,4 @@
-
+module S = Map.Make (String)
 module Level = struct
 type t = Format_tags.t
 let info = Format_tags.Info
@@ -83,7 +83,7 @@ type explanation = string
 
 type 'a info = {
   tag: 'a tag;
-  path: Paths.S.t;
+  path: string list;
   expl: explanation;
   printer: Format.formatter -> 'a -> unit
 }
@@ -106,7 +106,7 @@ module Policy = struct
 
   type map =
     | Level of {expl: explanation; lvl: Level.t option}
-    | Map of {expl:explanation; lvl:Level.t option; map: map Name.map}
+    | Map of {expl:explanation; lvl:Level.t option; map: map S.t}
 
   module Register = Map.Make(struct type t = dtag let compare=compare end)
   type t = {
@@ -131,7 +131,7 @@ module Policy = struct
     | Map m, a :: q  ->
       begin
         let h = with_default m.lvl in
-        try find_lvl h (Name.Map.find a m.map) q with
+        try find_lvl h (S.find a m.map) q with
           Not_found -> h
       end
     | Map m, [] -> with_default m.lvl
@@ -148,14 +148,14 @@ module Policy = struct
     | [], Map m -> Map { m with lvl; expl = Option.default m.expl expl }
     | a :: q, Level l ->
       Map{ lvl = None; expl = "";
-           map=Name.Map.singleton a @@ set ?lvl ?expl q @@ Level l
+           map=S.singleton a @@ set ?lvl ?expl q @@ Level l
          }
     | a :: q, Map m ->
       let env' =
         Option.default (Level {lvl=m.lvl; expl = m.expl})
-          (Name.Map.find_opt a m.map) in
+          (S.find_opt a m.map) in
       let elt = set ?lvl ?expl q env' in
-      let map = Name.Map.add a elt m.map in
+      let map = S.add a elt m.map in
       Map{m with map}
 
   let set ?lvl ?expl p pol = { pol with map = set ?lvl ?expl p pol.map }
@@ -182,7 +182,7 @@ module Policy = struct
         Format_tags.(tagged Title) name
         pp_lvl lvl
         expl
-        Pp.( list ~sep:(s "@;") @@ pp_map) (Name.Map.bindings map)
+        Pp.( list ~sep:(s "@;") @@ pp_map) (S.bindings map)
 
 
   let pp ppf pol = Pp.fp ppf "%a@." pp_map ("Policy",pol.map)

--- a/lib/fault.mli
+++ b/lib/fault.mli
@@ -32,14 +32,14 @@ type 'data tag
 
 type 'data info = {
   tag: 'data tag;
-  path : Paths.S.t (** hierarchical name for the fault *);
+  path : string list (** hierarchical name for the fault *);
   expl: explanation (** fault documentation *);
   printer: Format.formatter -> 'data -> unit;
 }
 
 type 'a printer = Format.formatter -> 'a -> unit
 
-val info: Paths.S.t  -> explanation  -> 'data printer -> 'data info
+val info: string list -> explanation  -> 'data printer -> 'data info
 
 type fault = Err: 'data tag * 'data -> fault
 type t = fault
@@ -76,7 +76,7 @@ sig
 
   (** {2 Utility functions} *)
   val level : t -> fault -> Level.t
-  val set: ?lvl:Level.t -> ?expl:explanation -> Paths.S.t -> t -> t
+  val set: ?lvl:Level.t -> ?expl:explanation -> string list -> t -> t
   val register: ?lvl:Level.t -> 'a info -> t -> t
 
   val set_exit: Level.t -> t -> t

--- a/tests/run.ml
+++ b/tests/run.ml
@@ -615,9 +615,9 @@ let result =
           "m2l.ml", (["Loc"; "Deps"; "Module"; "Name";
                       "Option";"Paths"; "Pp"; "Schematic"; "Schematic_indices" ],
                      ["List"],[]);
-          "fault.ml", (["Format_tags"; "Option"; "Name";"Paths"; "Pp"],
-                          ["Array"; "Format"; "Map"],[]);
-          "fault.mli", (["Paths"], ["Format"],[]);
+          "fault.ml", (["Format_tags"; "Option"; "Pp"],
+                          ["Array"; "Format"; "Map"; "String"],[]);
+          "fault.mli", ([], ["Format"],[]);
           "format_tags.mli", ([],["Format"],[]);
           "format_compat.mli", ([],["Format"],[]);
           "id.mli", ( ["Pkg";"Pp"; "Schematic"],


### PR DESCRIPTION
This patch wants to clarify some types used by `fault.ml`. Currently, from a first reading, we can believe that `fault.ml` needs the module path view and the module name view. However, the usage is completely different when we talk about about "hierarchy" instead of module path. For the deletion of `Name.Map.t`, the objective is more to delete the dependency between `fault.ml` and `name.ml` - even if we redo the application of the `Map` functor. By this way, `fault.ml` has "less" dependencies which is conceptually good for a module which handle any kind of errors.