### PR TITLE
Raise an exception `Fatal` instead of `exit 1`

### DIFF
--- a/lib/fault.ml
+++ b/lib/fault.ml
@@ -44,6 +44,9 @@ let tag (type t) (): t tag =
 
 type 'a printer = Format.formatter -> 'a -> unit
 
+type value = Fmt : 'a printer * 'a -> value
+exception Fatal of value
+
 module Log = struct
 
   let msg lvl simple fatal critical printer ppf x=
@@ -75,7 +78,7 @@ let log i printer ppf x =
   else if i.level >= Level.critical then
     Log.critical printer ppf x
   else if i.level >= i.exit then
-    (fn x; exit 1)
+    (fn x; raise (Fatal (Fmt (printer, x))))
   else
     fn x
 

--- a/lib/fault.mli
+++ b/lib/fault.mli
@@ -42,8 +42,13 @@ type 'a printer = Format.formatter -> 'a -> unit
 val info: Paths.S.t  -> explanation  -> 'data printer -> 'data info
 
 type fault = Err: 'data tag * 'data -> fault
+type value = Fmt: 'data printer * 'data -> value
 type t = fault
 
+exception Fatal of value
+(** When an error is critic (see {!val:Level.critical}), we raise this exception
+    which contains the value that describes the critical problem which its
+    {i pretty-printer}. *)
 
 val emit: 'data info -> 'data -> t
 


### PR DESCRIPTION
It permits to give a chance to the library user to recover the control flow and deal with the raised critical error. Related to #28.