### PR TITLE
Avoid modulizing filename when reading file

### DIFF
--- a/core/single.ml
+++ b/core/single.ml
@@ -19,16 +19,16 @@ let to_m2l policy sig_only (k,f,_n) =
   match Common.classic k with
   | None -> None
   | Some k ->
-    match Read.file k f with
-    | _name, Ok x ->
+    match Read.file_raw k f with
+    | Ok x ->
       if sig_only then Some (k, M2l.Sig_only.filter x) else Some (k,x)
-    | _, Error (Ocaml (Syntax msg)) ->
+    | Error (Ocaml (Syntax msg)) ->
       Fault.raise policy Standard_faults.syntaxerr msg;
       Some(k, approx f)
-    | _, Error (Ocaml (Lexer msg)) ->
+    | Error (Ocaml (Lexer msg)) ->
       Fault.raise policy Standard_faults.lexerr (!Location.input_name,msg);
       Some(k, approx f)
-    | _, Error (Serialized e) ->
+    | Error (Serialized e) ->
       Standard_faults.schematic_errors policy (f,"m2l",e); None
 
 let approx_file _ _ ppf _param (_,f,_) =

--- a/lib/read.ml
+++ b/lib/read.ml
@@ -45,9 +45,7 @@ let source_file kind filename =
   Pparse.remove_preprocessed input_file;
   code
 
-let file {format;kind} filename =
-  let name = name filename in
-  name,
+let file_raw {format;kind} filename =
   match format with
   | Src | Parsetree -> source_file kind filename
   | M2l ->
@@ -62,3 +60,7 @@ let file {format;kind} filename =
         Error (Serialized Schematic.Ext.Unknown_format)
     end
   | Cmi  -> ok @@ Cmi.m2l filename
+
+let file {format;kind} filename =
+  let name = name filename in
+  name, file_raw {format;kind} filename

--- a/lib/read.mli
+++ b/lib/read.mli
@@ -21,3 +21,7 @@ val name: string -> Unitname.t
 
 val file: kind -> string ->
   Unitname.t * (M2l.t, error) result
+
+val file_raw: kind -> string -> (M2l.t, error) result
+(** [file_raw kind filename] reads the file [filename] in a format
+    specific to the file's [kind]. *)

--- a/lib/unit.ml
+++ b/lib/unit.ml
@@ -46,7 +46,7 @@ let proj u = { u with more = () }
 
 
 let read_file policy kind filename path : s =
-  let _name, code = Read.file kind filename in
+  let code = Read.file_raw kind filename in
   let precision, code = match code with
     | Ok c -> Exact, c
     | Error (Serialized e) ->


### PR DESCRIPTION
The original behavior was to modulize the filename in Read.file as a convenience to the caller.
Then the caller Unit.read_file would ignore the modulize filename.

This behavior is a bug because the codept user may have supplied a valid Namespaced.t for the file. The result would be:

     Invalid_argument("Impossible to modulize \"_init\" (from \"_init.ml\")")
     Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
     Called from Unitname.modulize in file "lib/unitname.ml", line 16, characters 2-109
     Called from Read.file in file "lib/read.ml", line 49, characters 13-26
     Called from Unit.read_file in file "lib/unit.ml", line 49, characters 20-43

1. Now a new Read.file_raw function is available that avoids the modulizing of the filename.

2. These callers do not need the modulizing so they have switched to Read.file_raw:
- Unit.read_file
- Single.to_m2l

*Testing.* Instead of using the default `Io.direct : Io.t` which uses `reader.m2l = Unit.read_file` (which uses `Pkg.local`), I have a custom version of `Io.t` that uses `Read.file_raw` but doesn't use `Pkg.local`. I have to avoid `Pkg.local` because that also modulizes the filename, and I don't have an easy fix for that.