### PR TITLE
Split directories on platform separator and /

### DIFF
--- a/lib/namespaced.ml
+++ b/lib/namespaced.ml
@@ -88,7 +88,7 @@ type set = Set.t
 
 let module_path_of_filename ?(nms=[]) filename =
   let name = Unitname.modulize filename in
-  match List.rev (Support.split_on_char Filename.dir_sep.[0] filename) with
+  match List.rev (Support.split_on_dirs filename) with
   | [] -> raise @@ Invalid_argument "Invalid name for a compilation unit"
   | _ ->
     { namespace = nms ;
@@ -97,7 +97,7 @@ let module_path_of_filename ?(nms=[]) filename =
 
 let filepath_of_filename ?(nms=[]) filename =
   let name = Unitname.modulize filename in
-  match List.rev (Support.split_on_char Filename.dir_sep.[0] filename) with
+  match List.rev (Support.split_on_dirs filename) with
   | [] -> raise @@ Invalid_argument "Invalid name for a compilation unit"
   | _filename :: r ->
     { namespace = nms @ List.rev r ;

--- a/lib/paths.ml
+++ b/lib/paths.ml
@@ -52,7 +52,7 @@ struct
     | a :: q -> a :: chop_extension q
 
   let parse_filename name =
-    let l = Support.split_on_char (String.get (Filename.dir_sep) 0) name in
+    let l = Support.split_on_dirs name in
     match List.rev l with
     | "" :: q -> List.rev q
     | l -> List.rev l

--- a/lib/support.ml
+++ b/lib/support.ml
@@ -44,6 +44,26 @@ let split_on_char sep s =
   let n = String.length s in
   split [] n (n-1)
 
+let split_on_dirs s =
+  let sep = Filename.dir_sep.[0] in
+  if sep = '/' then
+    split_on_char '/' s
+  else
+    let sub start stop =
+      String.sub s start (stop-start) in
+    let rec split l last pos =
+      if pos = 0 then      
+        if s.[pos] = sep || s.[pos] = '/' then
+          "" :: sub (pos+1) last :: l
+        else
+          sub pos last :: l
+      else if s.[pos] = sep || s.[pos] = '/' then
+        split (sub (pos+1) last :: l) pos (pos-1)
+      else
+        split l last (pos-1) in
+    let n = String.length s in
+    split [] n (n-1)
+
 let opt conv s = try Some(conv s) with Failure _ -> None
 
 let filter_map f l =

--- a/lib/support.mli
+++ b/lib/support.mli
@@ -21,6 +21,15 @@ val remove_extension: string -> string
 *)
 
 val split_on_char: char -> string -> string list
+
+val split_on_dirs: string -> string list
+(** [split_on_dirs path] splits the file path [path] on the platform's
+    directory seperator and on forward slashes ([/]).
+    
+    Forward slashes are always included as a split character because on
+    Windows the predominant means of accessing OCaml is through a Unix
+    emulation shell (Cygwin or MSYS2). *)
+
 val opt: ('a -> 'b) -> 'a -> 'b option
 val filter_map: ('a -> 'b option) -> 'a list -> 'b list
 


### PR DESCRIPTION
Fixes the common use of Cygwin/MSYS2 providing paths to `codept` on Windows.

Fixes https://github.com/Octachron/codept/issues/31.

All call sites that used `[split_on_char]` with the platform directory separator have switched to the new `[split_on_dirs]`.