### PR TITLE
Export the codept library

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -11,6 +11,7 @@
 
 (library
   (name codept_lib)
+  (public_name codept.lib)
   (wrapped false)
   (libraries compiler-libs.common)
   (flags (:standard -w -30))


### PR DESCRIPTION
Not sure that you want to export the library in this way but we need to export the library if a project wants to use the core of `codept`.