### PR TITLE
Strip carriage returns from files before processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 **/_build/**
 **/.merlin
+**/_opam/**
 tests/generated/star/m*.mli
 *.cm[ioax]
 *.cmxa

--- a/core/common.ml
+++ b/core/common.ml
@@ -26,7 +26,7 @@ type task =
 let compiler_dir =
   lazy (
     let ch = Unix.open_process_in "ocamlc -where" in
-    let s= input_line ch in
+    let s= Win32_compat.dos2unix (input_line ch) in
     close_in ch;
     s ^ "/"
   )

--- a/core/findlib.ml
+++ b/core/findlib.ml
@@ -18,7 +18,7 @@ let run cmd =
   let cin = Unix.open_process_in cmd in
   let rec read l =
   try
-    match input_line cin with
+    match Win32_compat.dos2unix (input_line cin) with
     | "" -> read l
     | s -> read (s::l)
   with

--- a/experimental/client/codept_client.ml
+++ b/experimental/client/codept_client.ml
@@ -66,7 +66,7 @@ let client socket =
     output_value ch query;
     flush ch;
     let rec read () =
-      match input_line inchan with
+      match Win32_compat.dos2unix (input_line inchan) with
       | exception End_of_file -> ()
       | s -> print_endline s; read () in
     read ()

--- a/lib/win32_compat.ml
+++ b/lib/win32_compat.ml
@@ -1,0 +1,7 @@
+let dos2unix s =
+  let len = String.length s in
+  let b = Buffer.create len in
+  for i = 0 to len - 1 do
+    match s.[i] with '\r' -> () | c -> Buffer.add_char b c
+  done;
+  Buffer.contents b

--- a/lib/win32_compat.mli
+++ b/lib/win32_compat.mli
@@ -1,0 +1,2 @@
+val dos2unix : string -> string
+(** [dos2unix s] removes carriage returns (ASCII 0x0D) from [s]. *)

--- a/tests/integrated.ml
+++ b/tests/integrated.ml
@@ -237,7 +237,7 @@ let extract_attribute x =
   let f = open_in x in
   let rec loop l =
     try
-      let nl = input_line f in
+      let nl = Win32_compat.dos2unix (input_line f) in
       try
         let att = Scanf.sscanf nl "[%@%@%@%s@]" (fun x -> x) in
         loop (att :: l)

--- a/tests/run.ml
+++ b/tests/run.ml
@@ -236,7 +236,7 @@ module Branch(Param:Stage.param) = struct
     let cmd = "ocamlc -where " in
     let cin = Unix.open_process_in cmd in
     try
-      [Filename.concat (input_line cin) "compiler-libs" ]
+      [Filename.concat (Win32_compat.dos2unix (input_line cin)) "compiler-libs" ]
     with
       End_of_file -> []
 


### PR DESCRIPTION
Fixes https://github.com/Octachron/codept/issues/38

All `input_line` invocations were wrapped in a function (`Win32_compat.dos2unix`) that strips the CRs except the one in `preprocessor.ml:preprocess`.