### PR TITLE
Split single opam into two

### DIFF
--- a/bundled/dune
+++ b/bundled/dune
@@ -1,6 +1,7 @@
 (library
   (name bundled)
   (libraries codept_lib)
+  (public_name codept-lib.bundled)
   (flags (:standard -w -33))
   (wrapped false)
 )

--- a/codept-lib.opam
+++ b/codept-lib.opam
@@ -15,12 +15,12 @@ Codept intends to be a dependency solver for OCaml project and an alternative to
 Both ocamldep and codept computes an over-approximation of the dependencies graph of OCaml project. However, codept uses whole project analysis to reduce the number of fictitious dependencies inferred at the project scale, whereas ocamldep is, by design, limited to local file analysis."""
 maintainer: ["Florian Angeletti <octa@polychoron.fr>"]
 authors: ["Florian Angeletti <octa@polychoron.fr>"]
-license: "GPL-3.0-or-later"
+license: "OCaml-LGPL-linking-exception"
 homepage: "https://github.com/Octachron/codept"
 bug-reports: "https://github.com/Octachron/codept/issues"
 depends: [
   "dune"
-  "codept-lib" {= version}
+  "menhir" {>= "20180523"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/dune-project
+++ b/dune-project
@@ -2,6 +2,7 @@
 (using menhir 2.0)
 
 (name codept)
+(version 0.12.0)
 (authors "Florian Angeletti <octa@polychoron.fr>")
 (maintainers "Florian Angeletti <octa@polychoron.fr>")
 (homepage https://github.com/Octachron/codept)
@@ -12,8 +13,25 @@
 
 (package
   (name codept)
-  (version 0.12.0)
   (license GPL-3.0-or-later)
+  (synopsis "Alternative ocaml dependency analyzer")
+  (depends dune (codept-lib (= :version)))
+  (description "Codept intends to be a dependency solver for OCaml project and an alternative to ocamldep. Compared to ocamldep, codept major features are:
+
+ * whole project analysis
+ * exhaustive warning and error messages
+ * structured format (s-expression or json) for dependencies
+ * uniform handling of delayed alias dependencies
+ * (experimental) full dependencies,
+  when dependencies up to transitive closure are not enough
+
+Both ocamldep and codept computes an over-approximation of the dependencies graph of OCaml project. However, codept uses whole project analysis to reduce the number of fictitious dependencies inferred at the project scale, whereas ocamldep is, by design, limited to local file analysis."
+)
+)
+
+(package
+  (name codept-lib)
+  (license OCaml-LGPL-linking-exception)
   (synopsis "Alternative ocaml dependency analyzer")
   (depends dune (menhir (>= 20180523)))
   (description "Codept intends to be a dependency solver for OCaml project and an alternative to ocamldep. Compared to ocamldep, codept major features are:

--- a/dune-project
+++ b/dune-project
@@ -31,7 +31,7 @@ Both ocamldep and codept computes an over-approximation of the dependencies grap
 
 (package
   (name codept-lib)
-  (license OCaml-LGPL-linking-exception)
+  (license "LGPL-2.1-only WITH OCaml-LGPL-linking-exception")
   (synopsis "Alternative ocaml dependency analyzer")
   (depends dune (menhir (>= 20180523)))
   (description "Codept intends to be a dependency solver for OCaml project and an alternative to ocamldep. Compared to ocamldep, codept major features are:

--- a/lib/dune
+++ b/lib/dune
@@ -11,7 +11,7 @@
 
 (library
   (name codept_lib)
-  (public_name codept.lib)
+  (public_name codept-lib)
   (wrapped false)
   (libraries compiler-libs.common)
   (flags (:standard -w -30))


### PR DESCRIPTION
Based on the licensing in https://github.com/Octachron/codept/issues/6.

I have no idea if this is the split that was intended. It works with my use case, although `codept-bundled` is not essential.