### PR TITLE
fix state in local bind

### DIFF
--- a/lib/zipper_fold.ml
+++ b/lib/zipper_fold.ml
@@ -485,7 +485,6 @@ module Make(F:Zdef.fold)(Env:Stage.envt) = struct
         ~param ~ctx:(rm_loc ctx) ~state:state'
         body
       >>= fun body ->
-      let state = State.restart state diff in
       restart_minor (path: minor path) ~param ~ctx ~state
         (D.local_bind no x body)
     | Minor Local_open_left (diff0,loc_open,m) :: path ->

--- a/tests/cases/local_bind.ml
+++ b/tests/cases/local_bind.ml
@@ -1,0 +1,4 @@
+module R = struct end
+module M = struct let x = 0 end
+let () = let module Z = R in ()
+let () = let module Z = R in M.x

--- a/tests/cases/local_bind.ref
+++ b/tests/cases/local_bind.ref
@@ -1,0 +1,16 @@
+{
+"version":
+  [0, 11, 0],
+"dependencies":
+  [{
+   "file":
+     "cases/local_bind.ml"
+   }],
+"local":
+  [{
+   "module":
+     ["Local_bind"],
+   "ml":
+     "cases/local_bind.ml"
+   }]
+}


### PR DESCRIPTION
Thank you for this amazing project!

I ran into a tiny glitch when playing around, with a spurious "non-resolvable module Y" on the second instance of a `let module M = Y in ...` even though the first use of Y resolved correctly. This PR adds a test to document the issue, and the second commit is an attempt to fix it (I think the bug is just a one-character typo, but note that I don't understand the code enough to be sure).